### PR TITLE
Add project description and overview

### DIFF
--- a/.github/auto-merge.yml
+++ b/.github/auto-merge.yml
@@ -1,0 +1,4 @@
+# Docs: https://github.com/ahmadnassri/action-dependabot-auto-merge#githubworkflowsauto-mergeyml
+- match:
+    dependency_type: all
+    update_type: all

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,7 +2,6 @@
 # package ecosystems to update and where the package manifests are located.
 # Please see the documentation for all configuration options:
 # https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
-
 version: 2
 updates:
   - package-ecosystem: "github-actions"

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,0 +1,14 @@
+name: auto-merge
+
+on:
+  pull_request:
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: ahmadnassri/action-dependabot-auto-merge@v2
+        with:
+          github-token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}

--- a/docs/ecosystem/concepts.md
+++ b/docs/ecosystem/concepts.md
@@ -1,6 +1,6 @@
 # Concepts
 
-This document explains the underlying concepts and ideas of the microservice architecture.
+This document explains the underlying concepts and ideas of this library.
 
 > _TODO: Insert diagram that illustrates the correlation between **Channels**, **Gateways**, **Brokers** and **Services**._
 
@@ -10,11 +10,11 @@ A key concept of the architecture is the concept of channels. Channels are a can
 
 | Concept       | Resource action | Wildcard resource | Wildcard action |
 | ------------- | --------------- | ----------------- | --------------- |
-| Channel       | `pets.create`   | `>.create`        | `pets.>`        |
+| Channel       | `pets.create`   | `*.create`        | `pets.*`        |
 | HTTP endpoint | `POST /pets`    | `POST /*`         | `ALL /pets`     |
 | MQTT topic    | `pets/create`   | `#/create`        | `pets/#`        |
 | Redis channel | `pets.create`   | `*.create`        | `pets.*`        |
-| NATS subject  | `pets.create`   | `>.create`        | `pets.>`        |
+| NATS subject  | `pets.create`   | `*.create`        | `pets.*`        |
 
 ### Special channels
 
@@ -26,7 +26,7 @@ A key concept of the architecture is the concept of channels. Channels are a can
 
 Gateways make it possible to translate from protocols and their representations of hierarchies to the canonical format of channels. Below you may find a list of currently supported gateways:
 
-- **Web gateway** (`gateway-web`)  
+- **HTTP gateway** (`gateway-http`)  
   A gateway that converts HTTP requests into resource actions based on the HTTP method and the request path. With this gateway it is possible to expose event-driven services as RESTful HTTP API by simply deploying this gateway service.
 
 > _TODO: Conceptualize and document how the **Web gateway** for exposes endpoints that allow connecting to channels via **WebSockets**._

--- a/docs/ecosystem/overview.md
+++ b/docs/ecosystem/overview.md
@@ -1,0 +1,29 @@
+# Overview
+
+> Mycelium is Earth's natural Internet.  
+> \- Paul Staments
+
+Adopting, architecting and building microservices can be complex and complicated. Mykilio aims to tackle this complexity by providing an open ecosystem that allows developers to build applications quickly, supporting greenfield projects and gradual adoption of microservices alike.
+
+On a high level Mykilio tackles these challenges by drawing inspiration from other microservice frameworks, such as [Mainflux][docs-mainflux] and [Moleculer][website-moleculer] while also using well-defined specifications such as [CloudEvents][website-cloudevents].
+
+The long-term vision is to create an ecosystem of SDKs and services that allow developers to quickly build and deploy sharable services and deliver value to the customer. Currently, the key focus is on developing a stable SDK API that allows testing and adopting the ecosystem.
+
+## API stability
+
+| API stability | Description                                                                                                                                                    |
+| ------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| ✔️ `stable`   | The API is stable and maintained. There are no major breaking changes. The SDK has been tested, used in production and found to be reliable.                   |
+| ⚠️ `beta`     | The API is being finalized. Major breaking changes are not expected, but may happen for **internal APIs**. Usage in production should be considered with care. |
+| 🚨 `alpha`    | The API is under heavy development and subject to major breaking changes. Usage in production is strongly discouraged.                                         |
+
+## Language support
+
+Below you may find a list of the languages that are currently supported via SDKs.
+
+- 🚨 [Go][website-golang]: [`go get github.com/mykilio/mykilio.go`](https://github.com/mykilio/mykilio.go)
+
+[docs-mainflux]: https://mainflux.readthedocs.io/en/latest/
+[website-moleculer]: https://moleculer.services
+[website-cloudevents]: https://cloudevents.io/
+[website-golang]: https://golang.org/

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -9,6 +9,7 @@ use_directory_urls: no
 nav:
   - Home: index.md
   - Ecosystem:
+      - Overview: ecosystem/overview.md
       - Concepts: ecosystem/concepts.md
   - Contributors:
       - Contributing: contributors/contributing.md


### PR DESCRIPTION
Adds an overview page with a project description, which fixes the broken link on the frontpage. Additionally it closes #6.